### PR TITLE
Additional example of code example for setting segments_uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,21 @@ When pulling labels from Segments.ai, the operator will match fiftyone samples w
 ```python
 import fiftyone as fo
 dataset = fo.load_dataset("your_dataset")
-for sample in dataset:
+for sample in dataset.iter_samples(autosave=True,progress=True):
     # Somehow match the fo.Sample with the segments.ai sample
     sample["segments_uuid"] = "<UUID OF YOUR SAMPLE HERE>"
-    sample.save()
 ```
+
+Alternatively, this example uses FiftyOne's [set_values()][] method to perform a bulk update:
+
+[set_values()]: https://docs.voxel51.com/api/fiftyone.core.dataset.html?highlight=set_values#fiftyone.core.dataset.Dataset.set_values
+
+```python
+import fiftyone as fo
+dataset = fo.load_dataset("your_dataset")
+dataset.set_values("segments_uuid",your_values_map,key_field=your_key)
+```
+
 
 Current limitations:
  - It's currently not possible to pull annotations for Segments.ai sequences.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ dataset = fo.load_dataset("your_dataset")
 dataset.set_values("segments_uuid",your_values_map,key_field=your_key)
 ```
 
-
 Current limitations:
  - It's currently not possible to pull annotations for Segments.ai sequences.
 


### PR DESCRIPTION
Provide an additional example for bulk-setting segments_uuid. The dictionary syntax of set_values() may be valuable to avoid needing to arrange the segments UUIDs in an ordered list.